### PR TITLE
fix: Fixed the issue with adding description to branch

### DIFF
--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -68,7 +68,7 @@ customCommands:
         body: "Are you sure you want to remove description?"
   - key: "e"
     description: "Add/edit a branch description"
-    command: "git branch --edit-description"
+    command: "git branch --edit-description {{.SelectedLocalBranch.Name}}"
     context: "localBranches"
     loadingText: "Opening editor..."
     subprocess: true


### PR DESCRIPTION
Previously the adding description is only possible if checkout to the specific branch. Now adding description is possible upon selecting the branch without checkout, or switch branch.