### PR TITLE
fix: Rectify Lazygit custom keymaps malfunction

### DIFF
--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -65,11 +65,11 @@ customCommands:
     context: "files"
     description: "toggle file staged"
   - key: "<c-c>"
-    command: 'git log {{.SelectedLocalBranch.Name}}..HEAD --oneline --ancestry-path --merges --pretty=format:"%h - %s" | grep -E "\(#\d+\)" | sed "s/^[0-9a-f]* //" | pbcopy'
+    command: 'git log {{.SelectedLocalBranch.Name}}..HEAD --oneline --merges --pretty=format:"%h - %s" | grep -E "\(#\d+\)" | sed "s/^[0-9a-f]* //" | pbcopy'
     description: "Copy all merged commits messages with ticket number"
     context: "localBranches"
   - key: "<c-x>"
-    command: 'git log {{.SelectedLocalBranch.Name}}..HEAD --oneline --ancestry-path --merges --pretty=format:"%h - %s" | sed "s/^[0-9a-f]* //" | pbcopy'
+    command: 'git log {{.SelectedLocalBranch.Name}}..HEAD --oneline --merges --pretty=format:"%h - %s" | sed "s/^[0-9a-f]* //" | pbcopy'
     description: "Copy all merged commits messages"
     context: "localBranches"
   - key: "C"


### PR DESCRIPTION
The custom keymaps in Lazygit, designed to facilitate copying the list of unmerged commits, have been corrected. The malfunction was due to the `--ancestry-path` flag in the git log command which has now been removed.