### PR TITLE
feat: Add the `showBranchCommitHash` setting

### DIFF
--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -15,6 +15,7 @@ gui:
   authorColors:
     "*": "#636da6"
   showIcons: true
+  showBranchCommitHash: true
   theme:
     selectedLineBgColor:
       - "#51566F" # set to `default` to have no background color


### PR DESCRIPTION
Update the lazygit config by adding the `showBranchCommitHash` to true, which shows the commit hashes alongside branch name.